### PR TITLE
fix:agp大于8时  作为依赖项编译报插件Namespace not specified

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.rex.flutter_subscreen_plugin'
     compileSdkVersion 31
 
     sourceSets {


### PR DESCRIPTION
修复当项目agp大于等于8时 subscreen_plugin编译报 Namespace not specified的问题