### PR TITLE
fix: 当不指定java编译版本时,导致 JVM 目标兼容性不一致的问题;

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,16 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'com.rex.flutter_subscreen_plugin'
     compileSdkVersion 31
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
具体修复的编译错误问题:
Execution failed for task ':flutter_subscreen_plugin:compileReleaseKotlin'. > 'compileReleaseJavaWithJavac' task (current target is 1.8) and 'compileReleaseKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version. Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain